### PR TITLE
required sudo for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: r
+
+sudo: required


### PR DESCRIPTION
The travis build system was failing because it needed `sudo` privileges to install `R` on the test system.
